### PR TITLE
re #1108 adding test data for PlusTranverseProcessor test

### DIFF
--- a/ConfigFiles/Testing/PlusTransverseProcessEnhancerTestingParameters.xml
+++ b/ConfigFiles/Testing/PlusTransverseProcessEnhancerTestingParameters.xml
@@ -1,0 +1,43 @@
+ <PlusConfiguration version="2.1">
+  <DataCollection StartupDelaySec="1.0" >
+    <Device
+      Id="BoneEnhancer"
+      Type="ImageProcessor" >
+      <InputChannels>
+        <InputChannel Id="VideoStream" />
+      </InputChannels>
+      <OutputChannels>
+        <OutputChannel Id="TrackedBoneVideoStream" VideoDataSourceId="Video" />
+      </OutputChannels>
+      <Processor Type="vtkPlusTransverseProcessEnhancer" NumberOfScanLines="200" NumberOfSamplesPerScanLine="210">
+          <ScanConversion 
+            TransducerName="Ultrasonix_C5-2"
+            TransducerGeometry="CURVILINEAR"
+            RadiusStartMm="50.0"
+            RadiusStopMm="120.0"
+            ThetaStartDeg="-24"
+            ThetaStopDeg="24"
+            OutputImageSizePixel="820 616"
+            TransducerCenterPixel="410 110"
+            OutputImageSpacingMmPerPixel="0.1526 0.1526"
+            NumberOfSamplesPerScanLine="210"/>
+          <ImageProcessingOperations
+            ConvertToLinesImage="True"          
+            ThresholdingEnabled="True"
+            GaussianEnabled="True"
+            EdgeDetectorEnabled="True"
+            IslandRemovalEnabled="True"
+            ErosionEnabled="True"
+            DilationEnabled="True"
+            ReconvertBinaryToGreyscale="True"
+            ReturnToFanImage="True">
+            <GaussianSmoothing GaussianStdDev="3" GaussianKernelSize="5"/>
+            <Thresholding ThresholdOutValue="0" LowerThreshold="30" UpperThreshold="255"/>
+            <IslandRemoval IslandAreaThreshold="700"/>
+            <Erosion ErosionKernelSize="5 5"/>
+            <Dilation DilationKernelSize="15 5"/>
+          </ImageProcessingOperations>
+      </Processor>
+    </Device>
+  </DataCollection>
+</PlusConfiguration>


### PR DESCRIPTION
In response to issue #194 on Git, where it was mentioned that the PlusTranverseProcessor test lacks data. This includes two files that allow for the test to be run.