### PR TITLE
Incorporate frame tracking into vtkPlusTransverseProcessor configuration files

### DIFF
--- a/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_1ImageAcquisition.xml
+++ b/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_1ImageAcquisition.xml
@@ -2,16 +2,35 @@
   <DataCollection StartupDelaySec="1.0" >
     <DeviceSet 
       Name="PlusServer: Ultrasound transverse process enhancer component 1: Input connection"
-      Description="Acquires ultrasound images and transmits them for processing to a 64-bit server at port 18945 running the transverse process enhancer"/>
-	  
+      Description="This 32 bit server runs on ultrasound machine, acquires images and tracking transforms, and transmits them to and OpenIGTLink client at port 18944 (with host address of machine running this server) in Slicer on the 64 bit processing machine"/>
+    
+    <Device 
+      Id="TrackerDevice" 
+      Type="Ascension3DG" 
+      LocalTimeOffsetSec="0.0" 
+      FilterAcWideNotch="1"
+      ToolReferenceFrame="Tracker" >
+      <DataSources>
+        <DataSource Type="Tool" Id="Probe" PortName="0"  />
+        <DataSource Type="Tool" Id="Reference" PortName="1"  />
+      </DataSources>
+      <OutputChannels>
+        <OutputChannel Id="TrackerStream" >
+          <DataSource Id="Probe"/>
+          <DataSource Id="Reference"/>
+        </OutputChannel>
+      </OutputChannels>
+    </Device>
+    
     <Device
-      Id="TrackedVideoDevice"
+      Id="VideoDevice"
       Type="SonixVideo" 
       AcquisitionRate="30"
+      Depth="100"
       AutoClipEnabled="TRUE"
       ImageGeometryOutputEnabled="TRUE"
-      ImageToTransducerTransformName="ImageToTransducer"
-      IP="130.15.7.20" >
+      ImageToTransducerTransformName="ImageToProbe"
+      IP="130.15.7.75" >
       <DataSources>
         <DataSource Type="Video" Id="Video" PortName="B" PortUsImageOrientation="UF"  />
       </DataSources>
@@ -19,9 +38,21 @@
         <OutputChannel Id="VideoStream" VideoDataSourceId="Video" />
       </OutputChannels>
     </Device>
-	
-	<!-- This device gives you the option to save sequences to files for testing offline. -->
-	<Device
+  
+    <Device 
+      Id="TrackedVideoDevice" 
+      Type="VirtualMixer" >
+      <InputChannels>
+        <InputChannel Id="TrackerStream" />
+        <InputChannel Id="VideoStream" />
+      </InputChannels>
+      <OutputChannels>
+        <OutputChannel Id="TrackedVideoStream"/>
+      </OutputChannels>
+    </Device>
+  
+    <!-- This device gives you the option to save sequences to files for testing offline. -->
+    <Device
       Id="CaptureDevice"
       Type="VirtualCapture"
       BaseFilename="Recording.mha"
@@ -33,22 +64,30 @@
 
   </DataCollection>
   
-    
   <!-- Enable this Server's port in Slicer to see the input image along with the processed image -->
   <PlusOpenIGTLinkServer 
     MaxNumberOfIgtlMessagesToSend="1" 
     MaxTimeSpentWithProcessingMs="50" 
-    ListeningPort="18945" 
+    ListeningPort="18944" 
     SendValidTransformsOnly="true" 
-    OutputChannelId="VideoStream" > 
+    OutputChannelId="TrackedVideoStream" > 
     <DefaultClientInfo> 
       <MessageTypes> 
         <Message Type="IMAGE" />
+        <Message Type="TRANSFORM" />
       </MessageTypes>
+
+      <TransformNames> 
+        <Transform Name="ProbeToTracker" />
+        <Transform Name="ReferenceToTracker" />
+        <Transform Name="ProbeToReference" />
+      </TransformNames>
+      
       <ImageNames>
-        <Image Name="Image" EmbeddedTransformToFrame="Transducer" />
+        <Image Name="Image" EmbeddedTransformToFrame="Reference" /> <!-- Changing EmbeddedTransformToFrame from "Transducer" to "Reference" results in image appearing with tracking in Slicer automatically, though not under sent transform heirarchy -->
       </ImageNames>
+      
     </DefaultClientInfo>
   </PlusOpenIGTLinkServer>
-
+  
 </PlusConfiguration>

--- a/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_2Processing.xml
+++ b/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_2Processing.xml
@@ -2,25 +2,26 @@
   <DataCollection StartupDelaySec="1.0" >
     <DeviceSet 
       Name="PlusServer: Ultrasound transverse process enhancer component 2: Processing"
-      Description="Receives ultrasound images from the input connection at port 18945, enhances transverse process bone surfaces, and transmits the output on the default port 18944"/>
-
+      Description="Recieves ultrasound images from an OpenIGTLink server running on port 18945 in Slicer (add unproccessed images to Out channel for this connection), segments bone pixels with BoneEnhancer device, and sends the processed images back to Slicer via an OpenIGTLink client on port 18946.
+        NOTE: This configuration uses a custom TPImageToProbe transform as a workaround for transforms which not found in the TrackedVideoStream; it is geometrically incorrect. Place processed image volume under ProbeToReference transforms (sent from acquisition server) to see tracking" />
+      
     <Device
-      Id="TrackedVideoDevice"
+      Id="OpenIGTLinkVideoReceiveDevice"
       Type="OpenIGTLinkVideo"
       MessageType="TRACKEDFRAME"
       ServerAddress="localhost"
       ServerPort="18945"
+      ReconnectOnReceiveTimeout="false"
       IgtlMessageCrcCheckEnabled="false"
-      ImageToTransducerTransformName="ImageToTransducer"
-      LocalTimeOffsetSec="0" >
+      AcquisitionRate="30" >
       <DataSources>
         <DataSource Type="Video" Id="Video" BufferSize="50" PortUsImageOrientation="UF" />
       </DataSources>
       <OutputChannels>
-        <OutputChannel Id="VideoStream" VideoDataSourceId="Video" />
+        <OutputChannel Id="TrackedVideoStream" VideoDataSourceId="Video" />
       </OutputChannels>
     </Device>
-
+    
     <Device
       Id="BoneEnhancer"
       Type="ImageProcessor" >
@@ -28,7 +29,7 @@
         <DataSource Type="Video" Id="Video" PortUsImageOrientation="UF" />  
       </DataSources>
       <InputChannels>
-        <InputChannel Id="VideoStream" />
+        <InputChannel Id="TrackedVideoStream" />
       </InputChannels>
       <OutputChannels>
         <OutputChannel Id="BoneVideoStream" VideoDataSourceId="Video" />
@@ -42,7 +43,7 @@
           ThetaStartDeg="-24"
           ThetaStopDeg="24"
           OutputImageSizePixel="820 616"
-          TransducerCenterPixel="410 35"
+          TransducerCenterPixel="320 35"
           OutputImageSpacingMmPerPixel="0.1526 0.1526"
           NumberOfSamplesPerScanLine="210"/>
         <ImageProcessingOperations
@@ -63,52 +64,69 @@
           <Erosion ErosionKernelSize="5 5"/>
           <Dilation DilationKernelSize="10 5"/>
           
-          <!-- Only item DrawScanLines looks for NumberOfScanLines in -->
           <vtkPlusUsSimulatorAlgo   
-          ImageCoordinateFrame="Image"
-          ReferenceCoordinateFrame="Reference"
           IncomingIntensityMwPerCm2="300"
           BrightnessConversionGamma="0.2"
           BrighntessConversionOffset="30"
           NumberOfScanlines="128"
-          NumberOfSamplesPerScanline="1000"
+          NumberOfSamplesPerScanline="200"
           NoiseAmplitude="5.0"
           NoiseFrequency="2.5 3.5 1"
           NoisePhase="50 20 0"        
           />
         </ImageProcessingOperations>
       </Processor>
-    </Device>
+  </Device>
+  
+
+    <!-- This device allows you to save processed sequences to files for offline volume reconstruction. -->
+    <Device
+      Id="CaptureDevice"
+      Type="VirtualCapture"
+      BaseFilename="Recording.mha"
+      EnableCapturingOnStart="FALSE" >
+      <InputChannels>
+        <InputChannel Id="BoneVideoStream" />
+      </InputChannels>
+    </Device>  
   </DataCollection>
   
-   <CoordinateDefinitions>
-    <Transform From="TransverseProcessImage" To="Image"
-      Matrix="
-        1 0 0 0
-        0 1 0 0
-        0 0 1 0        
-        0 0 0 1" />
-    <Transform From="TransverseProcessImage" To="Transducer"
-      Matrix="
-        1 0 0 0
-        0 1 0 0
-        0 0 1 0        
-        0 0 0 1" />
-  </CoordinateDefinitions>
+  <CoordinateDefinitions>
 
+    <!-- TPImageToImage transform should be used with transforms in TrackedVideoStream to relate the processed images to the reference frame, but transforms in TrackedVideoStream cannot be found -->
+    <Transform From="TPImage" To="Image"
+      Matrix="
+        1 0 0 0
+        0 1 0 0
+        0 0 1 0        
+        0 0 0 1" />
+
+    <!-- TPImageToProbe custom transform is included here as a hack to relate processed images to some coordinate frame -->
+    <Transform From="TPImage" To="Probe"
+      Matrix="
+        1 0 0 0
+        0 1 0 0
+        0 0 1 0        
+        0 0 0 1" />
+
+  </CoordinateDefinitions>
+  
   <PlusOpenIGTLinkServer
     MaxNumberOfIgtlMessagesToSend="1"
     MaxTimeSpentWithProcessingMs="50"
-    ListeningPort="18944"
+    ListeningPort="18946"
     SendValidTransformsOnly="true"
     OutputChannelId="BoneVideoStream" >
     <DefaultClientInfo>
       <MessageTypes>
         <Message Type="IMAGE" />
       </MessageTypes>
+
       <ImageNames>
-        <Image Name="TransverseProcessImage" EmbeddedTransformToFrame="Transducer" />
+        <Image Name="TPImage" EmbeddedTransformToFrame="Probe" />
+        <!-- "Probe" for the embedded transform frame rather than "Reference" because the TPImageToProbe hack custom transform should not redefine the Reference coord frame -->
       </ImageNames>
+      
     </DefaultClientInfo>
   </PlusOpenIGTLinkServer>
 


### PR DESCRIPTION
Cc @cpinter 
Devices in the Acquisition config file set to collect and transmit transforms. The Processing config file is now set to work with US images sent from Slicer to the processing server. This makes use of a hack, the TPImageToProbe custom transform is geometrically incorrect and simply added because the server looks for this transform but cannot find it. File description elements updated to describe system setup with PlusServers and OpenIGTLink clients and server in Slicer.