### PR TITLE
Incorporates tracking with TransverseProcessEnhancer config files properly

### DIFF
--- a/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_1ImageAcquisition.xml
+++ b/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_1ImageAcquisition.xml
@@ -29,8 +29,7 @@
       Depth="100"
       AutoClipEnabled="TRUE"
       ImageGeometryOutputEnabled="TRUE"
-      ImageToTransducerTransformName="ImageToProbe"
-      IP="130.15.7.75" >
+      ImageToTransducerTransformName="ImageToProbe" >
       <DataSources>
         <DataSource Type="Video" Id="Video" PortName="B" PortUsImageOrientation="UF"  />
       </DataSources>

--- a/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_1ImageAcquisition.xml
+++ b/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_1ImageAcquisition.xml
@@ -2,7 +2,7 @@
   <DataCollection StartupDelaySec="1.0" >
     <DeviceSet 
       Name="PlusServer: Ultrasound transverse process enhancer component 1: Input connection"
-      Description="This 32 bit server runs on ultrasound machine, acquires images and tracking transforms, and transmits them to and OpenIGTLink client at port 18944 (with host address of machine running this server) in Slicer on the 64 bit processing machine"/>
+      Description="This 32-bit server runs on the Ultrasonix machine, acquires tracked frames, and transmits them to a PlusServer running on the 64-bit processing machine at port 18944."/>
     
     <Device 
       Id="TrackerDevice" 
@@ -50,17 +50,6 @@
         <OutputChannel Id="TrackedVideoStream"/>
       </OutputChannels>
     </Device>
-  
-    <!-- This device gives you the option to save sequences to files for testing offline. -->
-    <Device
-      Id="CaptureDevice"
-      Type="VirtualCapture"
-      BaseFilename="Recording.mha"
-      EnableCapturingOnStart="FALSE" >
-      <InputChannels>
-        <InputChannel Id="VideoStream" />
-      </InputChannels>
-    </Device>
 
   </DataCollection>
   
@@ -84,7 +73,7 @@
       </TransformNames>
       
       <ImageNames>
-        <Image Name="Image" EmbeddedTransformToFrame="Reference" /> <!-- Changing EmbeddedTransformToFrame from "Transducer" to "Reference" results in image appearing with tracking in Slicer automatically, though not under sent transform heirarchy -->
+        <Image Name="Image" EmbeddedTransformToFrame="Image" /> 
       </ImageNames>
       
     </DefaultClientInfo>

--- a/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_2Processing.xml
+++ b/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_2Processing.xml
@@ -2,13 +2,13 @@
   <DataCollection StartupDelaySec="1.0" >
     <DeviceSet 
       Name="PlusServer: Ultrasound transverse process enhancer component 2: Processing"
-      Description="Runs on 64-bit processing machine. Receives tracked ultrasound frames at port 18944 from the 32-bit PlusServer running on the Ultrasonix machine, segments bone surfaces, and sends tracked bone frames to an IGTLink client at port 18945 in Slicer" />
+      Description="Runs on 64-bit processing machine. Receives tracked ultrasound frames at port 18944 from the 32-bit PlusServer running on the Ultrasonix machine (change ServerAddress from localhost to Ultrasonix IP), segments bone surfaces, and sends tracked bone frames to an IGTLink client at port 18945 in Slicer" />
       
     <Device
       Id="OpenIGTLinkVideoReceiveDevice"
       Type="OpenIGTLinkVideo"
       MessageType="TRACKEDFRAME"
-      ServerAddress="130.15.7.75"
+      ServerAddress="localhost"
       ServerPort="18944"
       ReconnectOnReceiveTimeout="false"
       UseReceivedTimestamps="false" 

--- a/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_2Processing.xml
+++ b/ConfigFiles/PlusDeviceSet_Server_Ultrasonix_C5-2_TransverseProcessEnhancer_2Processing.xml
@@ -2,16 +2,16 @@
   <DataCollection StartupDelaySec="1.0" >
     <DeviceSet 
       Name="PlusServer: Ultrasound transverse process enhancer component 2: Processing"
-      Description="Recieves ultrasound images from an OpenIGTLink server running on port 18945 in Slicer (add unproccessed images to Out channel for this connection), segments bone pixels with BoneEnhancer device, and sends the processed images back to Slicer via an OpenIGTLink client on port 18946.
-        NOTE: This configuration uses a custom TPImageToProbe transform as a workaround for transforms which not found in the TrackedVideoStream; it is geometrically incorrect. Place processed image volume under ProbeToReference transforms (sent from acquisition server) to see tracking" />
+      Description="Runs on 64-bit processing machine. Receives tracked ultrasound frames at port 18944 from the 32-bit PlusServer running on the Ultrasonix machine, segments bone surfaces, and sends tracked bone frames to an IGTLink client at port 18945 in Slicer" />
       
     <Device
       Id="OpenIGTLinkVideoReceiveDevice"
       Type="OpenIGTLinkVideo"
       MessageType="TRACKEDFRAME"
-      ServerAddress="localhost"
-      ServerPort="18945"
+      ServerAddress="130.15.7.75"
+      ServerPort="18944"
       ReconnectOnReceiveTimeout="false"
+      UseReceivedTimestamps="false" 
       IgtlMessageCrcCheckEnabled="false"
       AcquisitionRate="30" >
       <DataSources>
@@ -34,7 +34,7 @@
       <OutputChannels>
         <OutputChannel Id="BoneVideoStream" VideoDataSourceId="Video" />
       </OutputChannels>
-      <Processor Type="vtkPlusTransverseProcessEnhancer" NumberOfScanLines="200" NumberOfSamplesPerScanLine="210">
+      <Processor Type="vtkPlusBoneEnhancer" NumberOfScanLines="200" NumberOfSamplesPerScanLine="210">
         <ScanConversion 
           TransducerName="Ultrasonix_C5-2"
           TransducerGeometry="CURVILINEAR"
@@ -78,43 +78,43 @@
       </Processor>
   </Device>
   
-
-    <!-- This device allows you to save processed sequences to files for offline volume reconstruction. -->
+    <!-- These capture devices allow you to save and compare the same sequence, before and after processing, if both EnableCapturingOnStart="True". -->
     <Device
-      Id="CaptureDevice"
+      Id="RawCaptureDevice"
       Type="VirtualCapture"
-      BaseFilename="Recording.mha"
-      EnableCapturingOnStart="FALSE" >
+      BaseFilename="RawRecording.mha"
+      EnableCapturingOnStart="False" >
+      <InputChannels>
+        <InputChannel Id="TrackedVideoStream" />
+      </InputChannels>
+    </Device>  
+    
+    <Device
+      Id="ProcessedCaptureDevice"
+      Type="VirtualCapture"
+      BaseFilename="ProcessedRecording.mha"
+      EnableCapturingOnStart="False" >
       <InputChannels>
         <InputChannel Id="BoneVideoStream" />
       </InputChannels>
-    </Device>  
+    </Device> 
+    
   </DataCollection>
   
   <CoordinateDefinitions>
-
-    <!-- TPImageToImage transform should be used with transforms in TrackedVideoStream to relate the processed images to the reference frame, but transforms in TrackedVideoStream cannot be found -->
-    <Transform From="TPImage" To="Image"
+  <Transform From="BoneImage" To="Image"
       Matrix="
         1 0 0 0
         0 1 0 0
         0 0 1 0        
         0 0 0 1" />
-
-    <!-- TPImageToProbe custom transform is included here as a hack to relate processed images to some coordinate frame -->
-    <Transform From="TPImage" To="Probe"
-      Matrix="
-        1 0 0 0
-        0 1 0 0
-        0 0 1 0        
-        0 0 0 1" />
-
   </CoordinateDefinitions>
   
+  <!-- Enable this Server's port in Slicer to see the processed image -->
   <PlusOpenIGTLinkServer
     MaxNumberOfIgtlMessagesToSend="1"
     MaxTimeSpentWithProcessingMs="50"
-    ListeningPort="18946"
+    ListeningPort="18945"
     SendValidTransformsOnly="true"
     OutputChannelId="BoneVideoStream" >
     <DefaultClientInfo>
@@ -123,8 +123,7 @@
       </MessageTypes>
 
       <ImageNames>
-        <Image Name="TPImage" EmbeddedTransformToFrame="Probe" />
-        <!-- "Probe" for the embedded transform frame rather than "Reference" because the TPImageToProbe hack custom transform should not redefine the Reference coord frame -->
+        <Image Name="BoneImage" EmbeddedTransformToFrame="Image" />
       </ImageNames>
       
     </DefaultClientInfo>


### PR DESCRIPTION
Setting UseReceivedTimestamps to "false" seems to have solved our problems with the processing server being unable to find or use tracking information. Therefore the custom transform workaround is no longer necessary and was removed.

This also simplifies the setup; the processing server can receive tracked frames from the acquisition server without routing them through Slicer anymore. I updated port numbers and descriptions to reflect this.

Also, changed processor type to reflect changes of https://github.com/PlusToolkit/PlusLib/commit/fe12a12ccd86ad7d9336b1dce584c6dc88b53580 

Capture devices are disabled by default, affecting nothing.

Cc: @Sunderlandkyl 
Cc: @ungi 
Cc: @cpinter 
Cc: @lassoan 