### PR TITLE
Fixed BoundingBox typo in PlusDeviceSet_Server_BkProFocusOem.xml

### DIFF
--- a/ConfigFiles/PlusDeviceSet_Server_BkProFocusOem.xml
+++ b/ConfigFiles/PlusDeviceSet_Server_BkProFocusOem.xml
@@ -61,7 +61,7 @@
         <String Name="ProbeType" />
         <String Name="Origin" />
         <String Name="Angles" />
-        <String Name="BouningBox" />
+        <String Name="BoundingBox" />
         <String Name="Depths" />
         <String Name="LinearWidth" />
         <!-- Spacing are sent as separate messages, should be sent with image in the future. -->


### PR DESCRIPTION
The pull request https://github.com/PlusToolkit/PlusLib/pull/372 fixed the typo in the PlusLib, but PlusLibData also should be consistent.

When the pull request https://github.com/PlusToolkit/PlusLib/pull/375 is merged, and the bug https://github.com/PlusToolkit/PlusLib/issues/374 is fixed PLUS will also be able to send the ultrasound sector as meta information without using the string messages in PlusDeviceSet_Server_BkProFocusOem.xml