### PR TITLE
ENH: set the parameters visible in Slicer's Ultrasound Remote Control

### DIFF
--- a/ConfigFiles/Testing/PlusDeviceSet_CapistranoVideoSourceTest.xml
+++ b/ConfigFiles/Testing/PlusDeviceSet_CapistranoVideoSourceTest.xml
@@ -21,9 +21,13 @@
         <Parameter name="SoundVelocity" value="1532"/>
         <Parameter name="DepthMm" value="36"/>
         <Parameter name="ImageSize" value="550 700"/>
-        <Parameter name="Intensity" value="100"/>
+        <Parameter name="Intensity" value="255"/>
         <Parameter name="Contrast" value="150"/>
         <Parameter name="ZoomFactor" value="1.0"/>
+        <Parameter name="DynRangeDb" value="25"/>
+        <Parameter name="FrequencyMhz" value="10"/>
+        <Parameter name="PowerDb" value="15"/>
+        <Parameter name="FocusDepthPercent" value="50"/>
         <Parameter name="GainPercent" value="50 60 70"/>
       </UsImagingParameters>
       <DataSources>


### PR DESCRIPTION
This avoids continuous stream of error messages:

|ERROR|300.652000| Command execution failed| in M:\Dev\Plus\SPc\PlusLib\src\PlusServer\vtkPlusCommandProcessor.cxx(183)

which are caused by a decision that absence of a setting is interpreted as error:
https://github.com/PlusToolkit/PlusLib/blob/50fa158100edb131f1e85ff9fff88cc7176c2409/src/PlusServer/Commands/vtkPlusGetUsParameterCommand.cxx#L223-L241